### PR TITLE
Allow interleaved data on RTP as well

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -798,16 +798,15 @@ impl RtspConnection {
                         } else if let (ResponseMode::Play, Some(m)) =
                             (&mode, self.channels.lookup(d.channel_id()))
                         {
-                            if m.channel_type == ChannelType::Rtcp {
-                                debug!(
-                                    "ignoring interleaved data message on RTCP channel {} while \
+                            debug!(
+                                "ignoring interleaved data message on {:?} channel {} while \
                                      waiting for response to {} CSeq {}",
-                                    d.channel_id(),
-                                    method,
-                                    cseq
-                                );
-                                continue;
-                            }
+                                m.channel_type,
+                                d.channel_id(),
+                                method,
+                                cseq
+                            );
+                            continue;
                         }
 
                         if let Some(session_group) = options.session_group.as_ref() {


### PR DESCRIPTION
This is necessary for at least some versions of the open source [v4l2rtspserver](https://github.com/mpromonet/v4l2rtspserver). Namely whatever version is on the earlier [dafang-hacks](https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks) build that works better than the latest main one on my 64mb RAM camera :D

```
T20211228 22:43:57.782 tokio-runtime-worker tokio_util::codec::framed_impl] frame decoded from buffer
D20211228 22:43:57.782 tokio-runtime-worker retina::client] ignoring interleaved data message on Rtcp channel 1 while waiting for response to PLAY CSeq 4
T20211228 22:43:57.782 tokio-runtime-worker tokio_util::codec::framed_impl] attempting to decode a frame
T20211228 22:43:57.782 tokio-runtime-worker tokio_util::codec::framed_impl] frame decoded from buffer
D20211228 22:43:57.782 tokio-runtime-worker retina::client] ignoring interleaved data message on Rtp channel 0 while waiting for response to PLAY CSeq 4
T20211228 22:43:57.782 tokio-runtime-worker tokio_util::codec::framed_impl] attempting to decode a frame
T20211228 22:43:57.782 tokio-runtime-worker tokio_util::codec::framed_impl] frame decoded from buffer
D20211228 22:43:57.782 tokio-runtime-worker retina::client::parse] PLAY response described stream rtsp://192.168.xx.yy:8554/unicast/track2 in Uninit state
```

