### PR TITLE
v0.4.3: upgrade h264-reader crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## `v0.4.3` (2022-09-28)
+
+*   upgrade version of `h264-reader` crate. Compatibility note: Retina may now
+    be stricter about parsing H.264 parameters (SPS/PPS). In practice, with some
+    cameras this means unparseable "out-of-line" parameters (specified in the
+    SDP) will be ignored in favor of parseable "in-line" parameters (specified
+    within the RTP data stream).
+
 ## `v0.4.2` (2022-09-28)
 
 *   ignore unparseable SDP media, improving compatibility with TP-Link cameras,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,13 +190,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bitreader"
-version = "0.3.6"
+name = "bitstream-io"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84ea71c85d1fe98fe67a9b9988b1695bc24c0b0d3bfb18d4c510f44b4b09941"
-dependencies = [
- "cfg-if",
-]
+checksum = "97d524fdb78bf6dc6d2dc4c02043e4b4962ede0a17ae3e13f0ed211a7eda5897"
 
 [[package]]
 name = "bitvec"
@@ -1047,11 +1044,12 @@ dependencies = [
 
 [[package]]
 name = "h264-reader"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d87669bdeca3d51902f1bf1f2c71c8f514a8f3011d9b81e63719b374091da1"
+checksum = "a3c095862f1b74a6021f766321767e64fbec34fa76503debbe1da2c04ce23c2c"
 dependencies = [
- "bitreader",
+ "bitstream-io",
+ "hex-slice",
  "log",
  "memchr",
  "rfc6381-codec",
@@ -1086,6 +1084,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-slice"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5491a308e0214554f07a81d8944abe45f552871c12e3c3c6e7e5d354039a6c4c"
 
 [[package]]
 name = "hmac"
@@ -1780,10 +1784,10 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "retina"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "base64",
- "bitreader",
+ "bitstream-io",
  "bytes",
  "criterion",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["."]
 
 [package]
 name = "retina"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Scott Lamb <slamb@slamb.org>"]
 license = "MIT/Apache-2.0"
 edition = "2021"
@@ -17,10 +17,10 @@ rust-version = "1.59"
 
 [dependencies]
 base64 = "0.13.0"
-bitreader = "0.3.3"
+bitstream-io = "1.1"
 bytes = "1.0.1"
 futures = "0.3.14"
-h264-reader = "0.5.0"
+h264-reader = "0.6.0"
 hex = "0.4.3"
 http-auth = "0.1.2"
 log = "0.4.8"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -21,13 +21,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
-name = "bitreader"
-version = "0.3.4"
+name = "bitstream-io"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9178181a7d44239c6c8eaafa8688558a2ab5fa04b8855381f2681e9591fb941b"
-dependencies = [
- "cfg-if",
-]
+checksum = "97d524fdb78bf6dc6d2dc4c02043e4b4962ede0a17ae3e13f0ed211a7eda5897"
 
 [[package]]
 name = "block-buffer"
@@ -230,11 +227,12 @@ dependencies = [
 
 [[package]]
 name = "h264-reader"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d87669bdeca3d51902f1bf1f2c71c8f514a8f3011d9b81e63719b374091da1"
+checksum = "a3c095862f1b74a6021f766321767e64fbec34fa76503debbe1da2c04ce23c2c"
 dependencies = [
- "bitreader",
+ "bitstream-io",
+ "hex-slice",
  "log",
  "memchr",
  "rfc6381-codec",
@@ -245,6 +243,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-slice"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5491a308e0214554f07a81d8944abe45f552871c12e3c3c6e7e5d354039a6c4c"
 
 [[package]]
 name = "http-auth"
@@ -511,10 +515,10 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "retina"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "base64",
- "bitreader",
+ "bitstream-io",
  "bytes",
  "futures",
  "h264-reader",

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -2508,10 +2508,8 @@ impl futures::Stream for Demuxed {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
     use super::*;
-    use crate::testutil::response;
+    use crate::testutil::{init_logging, response};
 
     /// Cross-platform, tokio equivalent of `socketpair(2)`.
     async fn socketpair() -> (tokio::net::TcpStream, tokio::net::TcpStream) {
@@ -2535,19 +2533,6 @@ mod tests {
             seen_unassigned: false,
         };
         (client, server)
-    }
-
-    fn init_logging() {
-        let h = mylog::Builder::new()
-            .set_format(
-                ::std::env::var("MOONFIRE_FORMAT")
-                    .map_err(|_| ())
-                    .and_then(|s| mylog::Format::from_str(&s))
-                    .unwrap_or(mylog::Format::Google),
-            )
-            .set_spec(::std::env::var("MOONFIRE_LOG").as_deref().unwrap_or("info"))
-            .build();
-        let _ = h.install();
     }
 
     /// Receives a request and sends a response, filling in the matching `CSeq`.

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -1,7 +1,22 @@
-// Copyright (C) 2021 Scott Lamb <slamb@slamb.org>
+// Copyright (C) 2022 Scott Lamb <slamb@slamb.org>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::str::FromStr;
+
 use bytes::Bytes;
+
+pub(crate) fn init_logging() {
+    let h = mylog::Builder::new()
+        .set_format(
+            ::std::env::var("MOONFIRE_FORMAT")
+                .map_err(|_| ())
+                .and_then(|s| mylog::Format::from_str(&s))
+                .unwrap_or(mylog::Format::Google),
+        )
+        .set_spec(::std::env::var("MOONFIRE_LOG").as_deref().unwrap_or("info"))
+        .build();
+    let _ = h.install();
+}
 
 pub(crate) fn response(raw: &'static [u8]) -> rtsp_types::Response<Bytes> {
     let (msg, len) = rtsp_types::Message::parse(raw).unwrap();


### PR DESCRIPTION
* match a couple h264-reader semantic changes. E.g., decode_nal now expects the full NALU including header byte.

* adjust test data in depacketize_parameter_change. The SDP parameters I used were invalid in a way caught only by the new h264-reader crate. That's not the intended scenario, so use different parameters. But mention the accidental scenario in CHANGELOG.md.

* initialize logging in h264 tests to ease debugging problems like the bullet above.

* in AAC code, match h264-reader's switch from bitreader to bitstream-io. This keeps dependencies down, in addition to the reasons for h264-reader's switch, described here: https://github.com/dholroyd/h264-reader/commit/7a02a3b7bd739e96ce262c852ea8b177e226f7f3