### PR TITLE
Tolerate Ubiquiti's useless `a=fmtp:96\r` in SDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## unreleased
+
+*   improve interop with Ubiquiti cameras by ignoring `fmtp` attributes in
+    SDP which have nothing (no required SP, no data) after the payload type.
+
 ## `v0.4.3` (2022-09-28)
 
 *   upgrade version of `h264-reader` crate. Compatibility note: Retina may now

--- a/src/client/testdata/ubiquiti_sdp.txt
+++ b/src/client/testdata/ubiquiti_sdp.txt
@@ -1,0 +1,25 @@
+v=0
+o=- 221 0 IN IP4 192.168.0.1
+s=68D79AE46148_0
+u=www.evostream.com
+e=contact@evostream.com
+c=IN IP4 192.168.0.1
+t=0 0
+a=recvonly
+a=control:*
+a=range:npt=now-
+m=audio 0 RTP/AVP 96
+a=recvonly
+a=rtpmap:96 mpeg4-generic/48000/1
+a=control:trackID=0
+a=fmtp:96 streamtype=5; profile-level-id=15; mode=AAC-hbr; config=1188; SizeLength=13; IndexLength=3; IndexDeltaLength=3;
+m=audio 0 RTP/AVP 96
+a=recvonly
+a=rtpmap:96 opus/48000/2
+a=control:trackID=1
+a=fmtp:96
+m=video 0 RTP/AVP 97
+a=recvonly
+a=control:trackID=2
+a=rtpmap:97 H264/90000
+a=fmtp:97 profile-level-id=4d402a; packetization-mode=1; sprop-parameter-sets=Z01AKo2NQDwBE/LgLcBAQFAAAD6AABX5CdoIhGo=,aO44gA==


### PR DESCRIPTION
See #65