### PR TITLE
Add ability to parse Annex B stream in FU-A

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+out.mp4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,7 +1704,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "retina"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "base64",
  "bitstream-io",

--- a/src/codec/h264.rs
+++ b/src/codec/h264.rs
@@ -1741,7 +1741,7 @@ mod tests {
             _ => panic!(),
         };
         assert_eq!(
-            &frame.data()[..],
+            frame.data(),
             b"\
             \x00\x00\x00\x26\
             \x27\

--- a/src/codec/h264.rs
+++ b/src/codec/h264.rs
@@ -108,7 +108,7 @@ impl NalParser {
                 if self.seen_second_zero_at.unwrap_or(0) - self.seen_one_zero_at.unwrap_or(0) == 1
                     && idx - self.seen_second_zero_at.unwrap_or(0) == 1
                 {
-                    debug!("Found boundary, idx range: {} - {}", idx - 2, idx);
+                    debug!("Found boundary with index range: {} - {}.", idx - 2, idx);
                     // we found a boundary, let NalParser know that it should now keep adding
                     // to last NAL even if the next FU-A frag header byte does not match the
                     // header of the last saved NAL.

--- a/src/codec/h264.rs
+++ b/src/codec/h264.rs
@@ -41,8 +41,16 @@ pub(crate) struct Depacketizer {
     nal_parser: NalParser,
 }
 
-/// Contains logic that converts RTP payload into NALs.
-/// [Depacketizer] delegates the conversion to this struct.
+/// Parses Annex B sequences from RTP NAL data.
+///
+/// RFC 6184 describes how NAL units should be represented by RTP packets. `Depacketizer` should map each
+/// such NAL unit to 1 call to `NalParser::start_rtp_nal`, then 1 or more calls to `NalParser::append_rtp_nal`,
+/// then 1 call to `NalParser::end_rtp_nal`.
+///
+/// If the camera complies with the RFC, this will add exactly one NAL unit. However, what some cameras
+/// call a single NAL unit is actually a sequence of multiple NAL units with Annex B separators. `NalParser`
+/// looks for these separators and adds multiple NAL units as needed.
+/// See [scottlamb/retina#68](https://github.com/scottlamb/retina/issues/68).
 #[derive(Debug)]
 struct NalParser {
     /// In state `PreMark`, pieces of NALs, excluding their header bytes.

--- a/src/codec/h264.rs
+++ b/src/codec/h264.rs
@@ -87,15 +87,54 @@ impl NalParser {
     /// boundaries (i.e. three consecutive 0x00). If it finds a boundary, it splits on it
     /// to break apart NALs from the Annex B stream.
     fn break_apart_nals(&mut self, data: Bytes) -> Result<bool, String> {
+        // Should `&mut Bytes` be passed instead of doing this?
+        let mut data_copy = data;
+
         let mut nal_start_idx = 0;
         let mut did_find_boundary = false;
 
-        for (idx, byte) in data.iter().enumerate() {
+        // Check if current packet starts with either a single or two 0x00 bytes.
+        // If so, check if previous piece ended with either one or two 0x00 bytes.
+        // Case 1: [ [.., 0x00], [pkt_header, nal_header, 0x00, 0x00, ..] ]
+        // Case 2: [ [.., 0x00, 0x00], [pkt_header, nal_header, 0x00, ..] ]
+        // If we match any of the above cases, we remove the 0x00 that form the boundary
+        // and start off a new nal after it.
+        if !self.pieces.is_empty() && data_copy.slice(..2)[..] == [0x00; 2] {
+            let last_piece = self
+                .pieces
+                .last_mut()
+                .expect("pieces should be non-empty because break_apart_nals checked for it to be non-empty");
+            if last_piece.ends_with(&[0x00]) {
+                let last_byte_index = last_piece.len() - 1;
+                last_piece.truncate(last_byte_index);
+                self.nals.last_mut().unwrap().len -= 1;
+                data_copy.advance(3);
+                let nal_header = NalHeader::new(data_copy[0]).expect("Header w/o F bit is valid");
+                self.start_rtp_nal(nal_header)?;
+                data_copy.advance(1);
+            }
+        } else if !self.pieces.is_empty() && data_copy.first().unwrap() == &0x00 {
+            let last_piece = self
+                .pieces
+                .last_mut()
+                .expect("pieces should be non-empty because break_apart_nals checked for it to be non-empty");
+            if last_piece.ends_with(&[0x00, 0x00]) {
+                let last_byte_index = last_piece.len() - 1;
+                last_piece.truncate(last_byte_index - 1);
+                self.nals.last_mut().unwrap().len -= 1;
+                data_copy.advance(2);
+                let nal_header = NalHeader::new(data_copy[0]).expect("Header w/o F bit is valid");
+                self.start_rtp_nal(nal_header)?;
+                data_copy.advance(1);
+            }
+        }
+
+        for (idx, byte) in data_copy.iter().enumerate() {
             // TODO: Handle boundaries split b/w packets.
             // If the current FU-A has a boundary that splits at end, ignore the last or
             // last two zeros because this boundary will be handled when the start of
             // next packet is being read, and these zeros will be removed on walk-back.
-            if byte == &0x00 && idx + 2 < data.len() && data[idx..idx + 3] == [0x00; 3] {
+            if byte == &0x00 && idx + 2 < data_copy.len() && data_copy[idx..idx + 3] == [0x00; 3] {
                 debug!("Found boundary with index range: {} - {}.", idx, idx + 2);
                 // we found a boundary, let NalParser know that it should now keep adding
                 // to last NAL even if the next FU-A frag header byte does not match the
@@ -103,7 +142,7 @@ impl NalParser {
                 did_find_boundary = true;
                 let nal_end_idx = idx;
 
-                let nal = data.slice(
+                let nal = data_copy.slice(
                     if nal_start_idx == 0 {
                         // this is only for the first boundary, since `data` passed already has advanced 2 bytes
                         // to skip the packet type and NAL header
@@ -120,7 +159,7 @@ impl NalParser {
                 nal_start_idx = idx + 3;
 
                 // create new nal which'll get updated
-                let nal_header = data[idx + 4];
+                let nal_header = data_copy[idx + 4];
                 self.nals.push(Nal {
                     hdr: NalHeader::new(nal_header).expect("header w/o F bit set is valid"),
                     next_piece_idx: u32::MAX,
@@ -131,7 +170,7 @@ impl NalParser {
 
         // if we had found a boundary, we need to add the last NAL to pieces now
         if did_find_boundary {
-            self.push(data.slice(nal_start_idx + 2..))?;
+            self.push(data_copy.slice(nal_start_idx + 2..))?;
         }
 
         Ok(did_find_boundary)
@@ -1112,10 +1151,12 @@ enum PacketizerState {
 mod tests {
     use std::num::NonZeroU32;
 
-    use h264_reader::nal::UnitType;
+    use h264_reader::nal::{NalHeader, UnitType};
 
     use crate::testutil::init_logging;
     use crate::{codec::CodecItem, rtp::ReceivedPacketBuilder};
+
+    use super::NalParser;
 
     /*
      * This test requires
@@ -1799,5 +1840,162 @@ mod tests {
             .unwrap(),
         );
         assert!(push_result.is_err());
+    }
+
+    #[test]
+    fn split_annex_b_from_single_packet() {
+        init_logging();
+        let timestamp = crate::Timestamp {
+            timestamp: 0,
+            clock_rate: NonZeroU32::new(90_000).unwrap(),
+            start: 0,
+        };
+        let rtp_pkt_1 = ReceivedPacketBuilder {
+            // FU-A start fragment
+            ctx: crate::PacketContext::dummy(),
+            stream_id: 0,
+            timestamp,
+            ssrc: 0,
+            sequence_number: 0,
+            loss: 0,
+            mark: false,
+            payload_type: 0,
+        }
+        .build(*b"\x3c\x07previous-nal\x00\x00\x00\x3c\x08new-nal")
+        .unwrap();
+
+        let rtp_payload = rtp_pkt_1.into_payload_bytes();
+        let nal_header = NalHeader::new(rtp_payload[1]).unwrap();
+
+        let mut nal_parser = NalParser::new();
+        nal_parser.start_rtp_nal(nal_header).unwrap();
+        nal_parser.append_rtp_nal(rtp_payload.slice(2..)).unwrap();
+
+        assert_eq!(nal_parser.nals.len(), 2);
+        assert_eq!(nal_parser.pieces.len(), 2);
+        assert_eq!(
+            nal_parser.nals.first().unwrap().hdr.nal_unit_type(),
+            UnitType::SeqParameterSet
+        );
+        assert_eq!(
+            nal_parser.nals.last().unwrap().hdr.nal_unit_type(),
+            UnitType::PicParameterSet
+        );
+    }
+
+    #[test]
+    fn split_annex_b_boundary_cut_off_between_packets_variation_one() {
+        init_logging();
+        let timestamp = crate::Timestamp {
+            timestamp: 0,
+            clock_rate: NonZeroU32::new(90_000).unwrap(),
+            start: 0,
+        };
+        let rtp_pkt_1 = ReceivedPacketBuilder {
+            // FU-A start fragment
+            ctx: crate::PacketContext::dummy(),
+            stream_id: 0,
+            timestamp,
+            ssrc: 0,
+            sequence_number: 0,
+            loss: 0,
+            mark: false,
+            payload_type: 0,
+        }
+        .build(*b"\x3c\x07previous-nal\x00\x00")
+        .unwrap();
+        let rtp_pkt_2 = ReceivedPacketBuilder {
+            // FU-A start fragment
+            ctx: crate::PacketContext::dummy(),
+            stream_id: 0,
+            timestamp,
+            ssrc: 0,
+            sequence_number: 0,
+            loss: 0,
+            mark: false,
+            payload_type: 0,
+        }
+        .build(*b"\x3c\x07\x00\x3c\x08new-nal")
+        .unwrap();
+
+        let rtp_1_payload = rtp_pkt_1.into_payload_bytes();
+        let rtp_2_payload = rtp_pkt_2.into_payload_bytes();
+        let nal_header_1 = NalHeader::new(rtp_1_payload[1]).unwrap();
+
+        let mut nal_parser = NalParser::new();
+        nal_parser.start_rtp_nal(nal_header_1).unwrap();
+        nal_parser.append_rtp_nal(rtp_1_payload.slice(2..)).unwrap();
+        assert_eq!(nal_parser.nals.len(), 1);
+        assert_eq!(nal_parser.pieces.len(), 1);
+        nal_parser.append_rtp_nal(rtp_2_payload.slice(2..)).unwrap();
+
+        assert_eq!(nal_parser.nals.len(), 2);
+        assert_eq!(nal_parser.pieces.len(), 2);
+        assert_eq!(
+            nal_parser.nals.first().unwrap().hdr.nal_unit_type(),
+            UnitType::SeqParameterSet
+        );
+        assert_eq!(
+            nal_parser.nals.last().unwrap().hdr.nal_unit_type(),
+            UnitType::PicParameterSet
+        );
+    }
+
+    #[test]
+    fn split_annex_b_boundary_cut_off_between_packets_variation_two() {
+        init_logging();
+        let timestamp = crate::Timestamp {
+            timestamp: 0,
+            clock_rate: NonZeroU32::new(90_000).unwrap(),
+            start: 0,
+        };
+        let rtp_pkt_1 = ReceivedPacketBuilder {
+            // FU-A start fragment
+            ctx: crate::PacketContext::dummy(),
+            stream_id: 0,
+            timestamp,
+            ssrc: 0,
+            sequence_number: 0,
+            loss: 0,
+            mark: false,
+            payload_type: 0,
+        }
+        .build(*b"\x3c\x07previous-nal\x00")
+        .unwrap();
+        let rtp_pkt_2 = ReceivedPacketBuilder {
+            // FU-A start fragment
+            ctx: crate::PacketContext::dummy(),
+            stream_id: 0,
+            timestamp,
+            ssrc: 0,
+            sequence_number: 0,
+            loss: 0,
+            mark: false,
+            payload_type: 0,
+        }
+        .build(*b"\x3c\x07\x00\x00\x3c\x08new-nal")
+        .unwrap();
+
+        let rtp_1_payload = rtp_pkt_1.into_payload_bytes();
+        let rtp_2_payload = rtp_pkt_2.into_payload_bytes();
+        let nal_header_1 = NalHeader::new(rtp_1_payload[1]).unwrap();
+
+        let mut nal_parser = NalParser::new();
+        nal_parser.start_rtp_nal(nal_header_1).unwrap();
+        nal_parser.append_rtp_nal(rtp_1_payload.slice(2..)).unwrap();
+        assert_eq!(nal_parser.nals.len(), 1);
+        assert_eq!(nal_parser.pieces.len(), 1);
+        nal_parser.append_rtp_nal(rtp_2_payload.slice(2..)).unwrap();
+
+        assert_eq!(nal_parser.nals.len(), 2);
+        assert_eq!(nal_parser.pieces.len(), 2);
+        assert_eq!(
+            nal_parser.nals.first().unwrap().hdr.nal_unit_type(),
+            UnitType::SeqParameterSet
+        );
+        assert_eq!(
+            nal_parser.nals.last().unwrap().hdr.nal_unit_type(),
+            UnitType::PicParameterSet
+        );
     }
 }

--- a/src/codec/h264.rs
+++ b/src/codec/h264.rs
@@ -94,7 +94,7 @@ impl NalParser {
             // If the current FU-A has a boundary that splits at end, ignore the last or
             // last two zeros because this boundary will be handled when the start of
             // next packet is being read, and these zeros will be removed on walk-back.
-            if byte == &0x00 && idx + 2 < data.len() && &data[idx..idx + 3] == &[0x00; 3] {
+            if byte == &0x00 && idx + 2 < data.len() && data[idx..idx + 3] == [0x00; 3] {
                 debug!("Found boundary with index range: {} - {}.", idx, idx + 2);
                 // we found a boundary, let NalParser know that it should now keep adding
                 // to last NAL even if the next FU-A frag header byte does not match the

--- a/src/codec/h264.rs
+++ b/src/codec/h264.rs
@@ -107,21 +107,13 @@ impl NalParser {
             if last_piece.ends_with(&[0x00]) {
                 let last_byte_index = last_piece.len() - 1;
                 last_piece.truncate(last_byte_index);
-                self.nals
-                    .last_mut()
-                    .expect("nals should be non-empty because pieces is non-empty")
-                    .len -= 1;
+                self.nals.last_mut().unwrap().len -= 1;
                 data_copy.advance(3);
                 let nal_header = NalHeader::new(data_copy[0]).expect("Header w/o F bit is valid");
                 self.start_rtp_nal(nal_header)?;
                 data_copy.advance(1);
             }
-        } else if !self.pieces.is_empty()
-            && data_copy
-                .first()
-                .expect("rtp payload should be non-empty because it passes through a len() check")
-                == &0x00
-        {
+        } else if !self.pieces.is_empty() && data_copy.first().unwrap() == &0x00 {
             let last_piece = self
                 .pieces
                 .last_mut()
@@ -129,10 +121,7 @@ impl NalParser {
             if last_piece.ends_with(&[0x00, 0x00]) {
                 let last_byte_index = last_piece.len() - 1;
                 last_piece.truncate(last_byte_index - 1);
-                self.nals
-                    .last_mut()
-                    .expect("nals should be non-empty because pieces is non-empty")
-                    .len -= 1;
+                self.nals.last_mut().unwrap().len -= 1;
                 data_copy.advance(2);
                 let nal_header = NalHeader::new(data_copy[0]).expect("Header w/o F bit is valid");
                 self.start_rtp_nal(nal_header)?;

--- a/src/codec/h264.rs
+++ b/src/codec/h264.rs
@@ -141,7 +141,6 @@ impl NalParser {
                 // header of the last saved NAL.
                 did_find_boundary = true;
                 let nal_end_idx = idx;
-                debug_assert!(nal_start_idx < nal_end_idx);
 
                 let nal = data_copy.slice(
                     if nal_start_idx == 0 {

--- a/src/codec/h264.rs
+++ b/src/codec/h264.rs
@@ -91,6 +91,9 @@ impl NalParser {
         let mut did_find_boundary = false;
 
         for (idx, byte) in data.iter().enumerate() {
+            // If the current FU-A has a boundary that splits at end, ignore the last or
+            // last two zeros because this boundary will be handled when the start of
+            // next packet is being read, and these zeros will be removed on walk-back.
             if byte == &0x00 && idx + 2 < data.len() && &data[idx..idx + 3] == &[0x00; 3] {
                 debug!("Found boundary with index range: {} - {}.", idx, idx + 2);
                 // we found a boundary, let NalParser know that it should now keep adding

--- a/src/codec/h264.rs
+++ b/src/codec/h264.rs
@@ -1165,6 +1165,8 @@ enum PacketizerState {
 mod tests {
     use std::num::NonZeroU32;
 
+    use h264_reader::nal::UnitType;
+
     use crate::testutil::init_logging;
     use crate::{codec::CodecItem, rtp::ReceivedPacketBuilder};
 
@@ -1691,5 +1693,164 @@ mod tests {
         };
         assert!(frame.has_new_parameters);
         assert!(d.parameters().is_some());
+    }
+
+    // FU-A packet containing Annex B stream (https://github.com/scottlamb/retina/issues/68)
+    #[test]
+    fn parse_annex_b_stream_in_fu_a() {
+        init_logging();
+        let mut d = super::Depacketizer::new(90_000, Some("profile-level-id=TQAf;packetization-mode=1;sprop-parameter-sets=J00AH+dAKALdgKUFBQXwAAADABAAAAMCiwEAAtxoAAIlUX//AoA=,KO48gA==")).unwrap();
+        let timestamp = crate::Timestamp {
+            timestamp: 0,
+            clock_rate: NonZeroU32::new(90_000).unwrap(),
+            start: 0,
+        };
+        d.push(
+            ReceivedPacketBuilder {
+                // FU-A start fragment which includes Annex B stream of 3 NALs
+                ctx: crate::PacketContext::dummy(),
+                stream_id: 0,
+                timestamp,
+                ssrc: 0,
+                sequence_number: 0,
+                loss: 0,
+                mark: false,
+                payload_type: 0,
+            }
+            .build(
+            *b"\
+            \x3c\x87\
+            \x4d\x00\x1f\xe7\x40\x28\x02\xdd\x80\xa5\x05\x05\x05\xf0\x00\x00\x03\x00\x10\x00\x00\x03\x02\x8b\x01\x00\x02\xdc\x68\x00\x02\x25\x51\x7f\xff\x02\x80\
+            \x00\x00\x00\
+            \x01\x28\
+            \xee\x3c\x80\
+            \x00\x00\x00\
+            \x01\x25\
+            idr-slice, "
+        )
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(d.pull().is_none());
+
+        // should've parsed Annex B stream from first FU-A frag into 3 NALs (SPS, PPS & IDR slice)
+        let number_of_nals_in_first_frag = 3;
+        assert!(d.nal_parser.nals.len() == number_of_nals_in_first_frag);
+        assert!(d.nal_parser.pieces.len() == number_of_nals_in_first_frag);
+        assert!(d.nal_parser.nals[0].hdr.nal_unit_type() == UnitType::SeqParameterSet);
+        assert!(d.nal_parser.nals[1].hdr.nal_unit_type() == UnitType::PicParameterSet);
+        assert!(
+            d.nal_parser.nals[2].hdr.nal_unit_type() == UnitType::SliceLayerWithoutPartitioningIdr
+        );
+
+        d.push(
+            ReceivedPacketBuilder {
+                // FU-A packet, middle.
+                ctx: crate::PacketContext::dummy(),
+                stream_id: 0,
+                timestamp,
+                ssrc: 0,
+                sequence_number: 1,
+                loss: 0,
+                mark: false,
+                payload_type: 0,
+            }
+            .build(*b"\x3c\x07idr-slice continued, ")
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(d.pull().is_none());
+
+        // For Annex B stream in FU-A, make sure we append next frags to the last nal
+        // instead of creating a new one from the frag header, since the header is of the starting
+        // NAL of previous frag, but instead is supposed to be the continuation of the last NAL from Annex B stream.
+
+        // This test will also test that retina shouldn't panic on receiving different nal headers in frags of
+        // a FU-A when the FU-A contains an Annex B stream.
+
+        // no new nals are to be created
+        assert!(d.nal_parser.nals.len() == number_of_nals_in_first_frag);
+        // data from frag will get appended
+        assert!(d.nal_parser.pieces.len() == number_of_nals_in_first_frag + 1);
+
+        d.push(
+            ReceivedPacketBuilder {
+                // FU-A packet, end.
+                ctx: crate::PacketContext::dummy(),
+                stream_id: 0,
+                timestamp,
+                ssrc: 0,
+                sequence_number: 2,
+                loss: 0,
+                mark: true,
+                payload_type: 0,
+            }
+            .build(*b"\x3c\x47idr-slice end")
+            .unwrap(),
+        )
+        .unwrap();
+
+        let frame = match d.pull() {
+            Some(CodecItem::VideoFrame(frame)) => frame,
+            _ => panic!(),
+        };
+        assert_eq!(
+            &frame.data()[..],
+            b"\
+            \x00\x00\x00\x26\
+            \x27\
+            \x4d\x00\x1f\xe7\x40\x28\x02\xdd\x80\xa5\x05\x05\x05\xf0\x00\x00\x03\x00\x10\x00\x00\x03\x02\x8b\x01\x00\x02\xdc\x68\x00\x02\x25\x51\x7f\xff\x02\x80\
+            \x00\x00\x00\
+            \x04\x28\
+            \xee\x3c\x80\
+            \x00\x00\x00\
+            \x2e\x25\
+            idr-slice, idr-slice continued, idr-slice end"
+        );
+    }
+
+    #[test]
+    fn exit_on_inconsistent_headers_between_fu_a() {
+        init_logging();
+        let mut d = super::Depacketizer::new(90_000, Some("profile-level-id=TQAf;packetization-mode=1;sprop-parameter-sets=J00AH+dAKALdgKUFBQXwAAADABAAAAMCiwEAAtxoAAIlUX//AoA=,KO48gA==")).unwrap();
+        let timestamp = crate::Timestamp {
+            timestamp: 0,
+            clock_rate: NonZeroU32::new(90_000).unwrap(),
+            start: 0,
+        };
+        d.push(
+            ReceivedPacketBuilder {
+                // FU-A start fragment which includes Annex B stream of 3 NALs
+                ctx: crate::PacketContext::dummy(),
+                stream_id: 0,
+                timestamp,
+                ssrc: 0,
+                sequence_number: 0,
+                loss: 0,
+                mark: false,
+                payload_type: 0,
+            }
+            .build(*b"\x3c\x81start of non-idr")
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(d.pull().is_none());
+
+        let push_result = d.push(
+            ReceivedPacketBuilder {
+                // FU-A packet, middle.
+                ctx: crate::PacketContext::dummy(),
+                stream_id: 0,
+                timestamp,
+                ssrc: 0,
+                sequence_number: 1,
+                loss: 0,
+                mark: false,
+                payload_type: 0,
+            }
+            .build(*b"\x3c\x07a wild sps appeared")
+            .unwrap(),
+        );
+        assert!(push_result.is_err());
     }
 }

--- a/src/codec/h264.rs
+++ b/src/codec/h264.rs
@@ -107,13 +107,21 @@ impl NalParser {
             if last_piece.ends_with(&[0x00]) {
                 let last_byte_index = last_piece.len() - 1;
                 last_piece.truncate(last_byte_index);
-                self.nals.last_mut().unwrap().len -= 1;
+                self.nals
+                    .last_mut()
+                    .expect("nals should be non-empty because pieces is non-empty")
+                    .len -= 1;
                 data_copy.advance(3);
                 let nal_header = NalHeader::new(data_copy[0]).expect("Header w/o F bit is valid");
                 self.start_rtp_nal(nal_header)?;
                 data_copy.advance(1);
             }
-        } else if !self.pieces.is_empty() && data_copy.first().unwrap() == &0x00 {
+        } else if !self.pieces.is_empty()
+            && data_copy
+                .first()
+                .expect("rtp payload should be non-empty because it passes through a len() check")
+                == &0x00
+        {
             let last_piece = self
                 .pieces
                 .last_mut()
@@ -121,7 +129,10 @@ impl NalParser {
             if last_piece.ends_with(&[0x00, 0x00]) {
                 let last_byte_index = last_piece.len() - 1;
                 last_piece.truncate(last_byte_index - 1);
-                self.nals.last_mut().unwrap().len -= 1;
+                self.nals
+                    .last_mut()
+                    .expect("nals should be non-empty because pieces is non-empty")
+                    .len -= 1;
                 data_copy.advance(2);
                 let nal_header = NalHeader::new(data_copy[0]).expect("Header w/o F bit is valid");
                 self.start_rtp_nal(nal_header)?;

--- a/src/codec/h264.rs
+++ b/src/codec/h264.rs
@@ -141,6 +141,7 @@ impl NalParser {
                 // header of the last saved NAL.
                 did_find_boundary = true;
                 let nal_end_idx = idx;
+                debug_assert!(nal_start_idx < nal_end_idx);
 
                 let nal = data_copy.slice(
                     if nal_start_idx == 0 {

--- a/src/codec/h264.rs
+++ b/src/codec/h264.rs
@@ -91,6 +91,7 @@ impl NalParser {
         let mut did_find_boundary = false;
 
         for (idx, byte) in data.iter().enumerate() {
+            // TODO: Handle boundaries split b/w packets.
             // If the current FU-A has a boundary that splits at end, ignore the last or
             // last two zeros because this boundary will be handled when the start of
             // next packet is being read, and these zeros will be removed on walk-back.


### PR DESCRIPTION
# Summary
Add ability to break apart an Annex B stream sent in a FU-A. Fixes #68 

# Details
My V380 cam would send a FU-A after establishing RTSP connection. The FU-A was not conformant to spec.

```
FU-A (start) => [ sps header - sps - boundary - pps header - pps - boundary - idr header - idr ] # Annex B stream
FU-A (...) => [ sps header - idr ]
FU-A (end) => [ sps header - idr ]
```

Notice how all the frags have the same header (as they should be), but the **start** has an Annex B stream, meaning the last NAL picked from that packet is an **IDR**. This means the last NAL saved from first packet will be an **IDR**, but the next fragment will have... the header for **SPS**, but data for **IDR**, which is wrong.

It appears that the camera only does this for FU-A that has SPS & PPS. FU-As & single NAL units for other NAL types are conformant to spec.

I have only modified this logic for the FU-A flow. We can however use the `start_rtp_nal`, `append_rtp_nal` and `end_rtp_nal` to handle all NAL types.

### Camera details
Name: V380 (It's a generic V380 outdoor camera)
Firmware: `HwV380E31_WF8_PTZ_WIFI_20201218` (I had asked them for a firmware update file to enable RTSP support)