### PR TITLE
RTSP: Trim whitespace from CSeq header before parsing

### DIFF
--- a/src/client/parse.rs
+++ b/src/client/parse.rs
@@ -212,7 +212,7 @@ fn join_control(base_url: &Url, control: &str) -> Result<Url, String> {
 pub(crate) fn get_cseq(response: &rtsp_types::Response<Bytes>) -> Option<u32> {
     response
         .header(&rtsp_types::headers::CSEQ)
-        .and_then(|cseq| u32::from_str_radix(cseq.as_str(), 10).ok())
+        .and_then(|cseq| u32::from_str_radix(cseq.as_str().trim(), 10).ok())
 }
 
 /// Parses a [MediaDescription] to a [Stream].


### PR DESCRIPTION
Working with Longse (also may share the same software/firmware with Herospeed) cameras we found that Retina was unable to communicate with these cameras. Upon analyzing the packets, we saw that these cameras were adding a space after the Cseq header value (So instead of `Cseq: 101\r\n`, we saw `Cseq: 101 \r\n`). 

This PR simply adds a `trim` method before the Cseq is parsed so that these cameras can be supported successfully.

[longse.pkt.zip](https://github.com/scottlamb/retina/files/10551755/longse.pkt.zip)
