### PR TITLE
Error: Add a status_code method on the Error struct to query the RTSP status code, if any

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,16 @@ use thiserror::Error;
 #[derive(Clone)]
 pub struct Error(pub(crate) Arc<ErrorInt>);
 
+impl Error {
+    /// Returns the status code, if the error was generated from a response.
+    pub fn status_code(&self) -> Option<u16> {
+        match self.0.as_ref() {
+            ErrorInt::RtspResponseError { status, .. } => Some((*status).into()),
+            _ => None,
+        }
+    }
+}
+
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)


### PR DESCRIPTION
This is useful to query the Error status code, for example, if the request was denied because the request was unauthorized due to the username/password being wrong. 