### PR TITLE
Add policy for handling session IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## unreleased
+
+*   add policy for handling session IDs. Required for some broken cameras which
+    can change the session ID between `SETUP` calls.
+
 ## `v0.4.5` (2023-02-02)
 
 *   minimum Rust version is now 1.64.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -279,7 +279,7 @@ impl SessionGroup {
 /// Policy for when to send `TEARDOWN` requests.
 ///
 /// Specify via [`SessionOptions::teardown`].
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub enum TeardownPolicy {
     /// Automatic.
     ///
@@ -294,6 +294,7 @@ pub enum TeardownPolicy {
     ///     on the existing connection. This is just in case; some servers appear
     ///     to be buggy but don't advertise buggy versions. After the single attempt,
     ///     closes the TCP connection and considers the session done.
+    #[default]
     Auto,
 
     /// Always send `TEARDOWN` requests, regardless of transport.
@@ -304,12 +305,6 @@ pub enum TeardownPolicy {
 
     /// Never send `TEARDOWN` or track stale sessions.
     Never,
-}
-
-impl Default for TeardownPolicy {
-    fn default() -> Self {
-        TeardownPolicy::Auto
-    }
 }
 
 impl std::fmt::Display for TeardownPolicy {
@@ -340,10 +335,11 @@ impl std::str::FromStr for TeardownPolicy {
 /// Policy for handling the `rtptime` parameter normally seem in the `RTP-Info` header.
 /// This parameter is used to map each stream's RTP timestamp to NPT ("normal play time"),
 /// allowing multiple streams to be played in sync.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub enum InitialTimestampPolicy {
     /// Default policy: currently `Require` when playing multiple streams,
     /// `Ignore` otherwise.
+    #[default]
     Default,
 
     /// Require the `rtptime` parameter be present and use it to set NPT. Use
@@ -359,12 +355,6 @@ pub enum InitialTimestampPolicy {
     /// specified for all of them; otherwise assume the first received packet
     /// for each stream is at NPT 0.
     Permissive,
-}
-
-impl Default for InitialTimestampPolicy {
-    fn default() -> Self {
-        InitialTimestampPolicy::Default
-    }
 }
 
 impl std::fmt::Display for InitialTimestampPolicy {

--- a/src/client/testdata/h264dvr_describe.txt
+++ b/src/client/testdata/h264dvr_describe.txt
@@ -1,0 +1,26 @@
+RTSP/1.0 200 OK
+Content-Type: application/sdp
+Server: H264DVR 1.0
+Cseq: 3
+Content-Base: rtsp://127.0.0.1:554/camera
+Cache-Control: private
+x-Accept-Retransmit: our-retransmit
+x-Accept-Dynamic-Rate: 1
+Content-Length: 418
+
+v=0
+o=- 38990265062388 38990265062388 IN IP4 127.0.0.1
+s=RTSP Session
+c=IN IP4 192.168.168.100
+t=0 0
+a=control:*
+a=range:npt=0-
+m=video 0 RTP/AVP 96
+a=rtpmap:96 H264/90000 
+a=range:npt=0-
+a=framerate:0S
+a=fmtp:96 profile-level-id=420029; packetization-mode=1; sprop-parameter-sets=Z0IAKZY1QPAET8s3AQEBQAAAAwBAAAAHoQ==,aM4xsg==
+a=framerate:25
+a=control:trackID=3
+m=audio 0 RTP/AVP 8
+a=control:trackID=4

--- a/src/client/testdata/h264dvr_play.txt
+++ b/src/client/testdata/h264dvr_play.txt
@@ -1,0 +1,6 @@
+RTSP/1.0 200 OK
+Server: H264DVR 1.0
+Cseq: 6
+Range: npt=now-
+Session: 231970
+

--- a/src/client/testdata/h264dvr_setup_audio.txt
+++ b/src/client/testdata/h264dvr_setup_audio.txt
@@ -1,0 +1,8 @@
+RTSP/1.0 200 OK
+Server: H264DVR 1.0
+Cseq: 5
+Session: 231980;timeout=60
+Transport: RTP/AVP;unicast;mode=PLAY;source=127.0.0.1;client_port=18716-18717;server_port=40006-40007;ssrc=0
+Cache-Control: private
+x-Dynamic-Rate: 1
+

--- a/src/client/testdata/h264dvr_setup_video.txt
+++ b/src/client/testdata/h264dvr_setup_video.txt
@@ -1,0 +1,8 @@
+RTSP/1.0 200 OK
+Server: H264DVR 1.0
+Cseq: 4
+Session: 231970;timeout=60
+Transport: RTP/AVP;unicast;mode=PLAY;source=127.0.0.1;client_port=18714-18715;server_port=40004-40005;ssrc=0
+Cache-Control: private
+x-Dynamic-Rate: 1
+


### PR DESCRIPTION
I don't know what model camera this is, but it calls itself 'H264DVR 1.0'. In typical garbage IP camera fashion, if you request only the video stream in UDP mode then it just hangs and doesn't send any RTP data. If you then humour it and request the unwanted audio stream, it (sometimes) returns a different session ID in the second `SETUP` response. This doesn't seem to actually cause any problems; when you send the `PLAY` request, both RTP streams start.

I don't think retina is doing anything wrong. Looking at the packet traces, the same thing happens with ffmpeg which seems to just ignore the new session ID.