### PR TITLE
Ignore UDP connection refused errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 *   add policy for handling session IDs. Required for some broken cameras which
     can change the session ID between `SETUP` calls.
+*   ignore connection refused errors triggered by the firewall punch-through
+    packets.
 
 ## `v0.4.5` (2023-02-02)
 


### PR DESCRIPTION
The packets sent by `punch_firewall_hole` can elicit a 'destination unreachable' ICMP response from the server, which gets turned into a 'connection refused' error. This is not actually a problem so just ignore them.