### PR TITLE
Add default User-Agent header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## unreleased
 
+*   add default User-Agent header
 *   add policy for handling session IDs. Required for some broken cameras which
     can change the session ID between `SETUP` calls.
 *   ignore connection refused errors triggered by the firewall punch-through

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1331,12 +1331,19 @@ impl RtspConnection {
             req.insert_header(rtsp_types::headers::AUTHORIZATION, authorization);
         }
         req.insert_header(rtsp_types::headers::CSEQ, cseq.to_string());
-        if let Some(ref u) = options.user_agent {
-            req.insert_header(rtsp_types::headers::USER_AGENT, u.to_string());
-        }
+
+        let user_agent = if let Some(ref u) = options.user_agent {
+            u
+        } else {
+            DEFAULT_USER_AGENT
+        };
+        req.insert_header(rtsp_types::headers::USER_AGENT, user_agent.to_string());
+
         Ok(cseq)
     }
 }
+
+const DEFAULT_USER_AGENT: &str = concat!("retina_", env!("CARGO_PKG_VERSION"));
 
 impl<S: State> Session<S> {
     /// Returns the available streams as described by the server.


### PR DESCRIPTION
I have a generic S3VC camera that responds with Unauthorized for DESCRIBE requests without a user agent header.

The spec doesn't mandate it but most libraries seem to have default value.

https://www.rfc-editor.org/rfc/rfc2326#section-12
https://github.com/FFmpeg/FFmpeg/blob/fc993e7a53c2e7a18f8d49b3a52cadf47580b82c/libavformat/rtsp.c#L103
https://github.com/AlexxIT/go2rtc/commit/da3137b6f08697cb7d5db0a3ee433148734996c4