### PR TITLE
Add codec features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,7 +1704,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "retina"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "base64",
  "bitstream-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ base64 = "0.21.0"
 bitstream-io = "1.1"
 bytes = "1.0.1"
 futures = "0.3.14"
-h264-reader = "0.7.0"
+h264-reader = { version = "0.7.0", optional = true }
 hex = "0.4.3"
 http-auth = "0.1.2"
 log = "0.4.8"
@@ -36,6 +36,14 @@ time = "0.1.43"
 tokio = { version = "1.11.0", features = ["macros", "net", "rt", "time"] }
 tokio-util = { version = "0.7.3", features = ["codec"] }
 url = "2.2.1"
+
+[features]
+default = ["aac", "g723", "onvif", "simple-audio", "h264"]
+aac = []
+g723 = []
+onvif = []
+simple-audio = []
+h264 = ["dep:h264-reader"]
 
 [dev-dependencies]
 criterion = { version = "0.5.0", features = ["async_tokio"] }


### PR DESCRIPTION
It allows users to strip some unneeded codec to reduce binary size.

`cargo bloat --all-features`:
```
117.8KiB retina
```

After `cargo bloat --no-default-features`:
```
84.2KiB retina
```