### PR TITLE
Add ability to parse Annex B stream in FU-A

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,7 +1704,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "retina"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "base64",
  "bitstream-io",

--- a/src/codec/h264.rs
+++ b/src/codec/h264.rs
@@ -423,7 +423,7 @@ impl Depacketizer {
     ) -> Result<(), String> {
         const START_CODE_4_BYTE: [u8; 4] = [0x00, 0x00, 0x00, 0x01];
 
-        assert_eq!(self.has_annex_b_stream, true);
+        assert!(self.has_annex_b_stream);
 
         // TODO: check for start code broken b/w two fragmented packets.
 


### PR DESCRIPTION
# Summary
Add ability to break apart an Annex B stream sent in a FU-A. Fixes #68 

# Details
My V380 cam would send a FU-A after establishing RTSP connection. The FU-A was not conformant to spec.

```
FU-A (start) => [ sps header - sps - boundary - pps header - pps - boundary - idr header - idr ] # Annex B stream
FU-A (...) => [ sps header - idr ]
FU-A (end) => [ sps header - idr ]
```

Notice how all the frags have the same header (as they should be), but the **start** has an Annex B stream, meaning the last NAL picked from that packet is an **IDR**. This means the last NAL saved from first packet will be an **IDR**, but the next fragment will have... the header for **SPS**, but data for **IDR**, which is wrong.

It appears that the camera only does this for FU-A that has SPS & PPS. FU-As & single NAL units for other NAL types are conformant to spec.

I have only modified this logic for the FU-A flow.

### Camera details
Name: V380 (It's a generic V380 outdoor camera)
Firmware: `HwV380E31_WF8_PTZ_WIFI_20201218` (I had asked them for a firmware update file to enable RTSP support)