### PR TITLE
fix: connection failed with some cctv

### DIFF
--- a/src/client/parse.rs
+++ b/src/client/parse.rs
@@ -547,8 +547,9 @@ pub(crate) fn parse_setup(response: &rtsp_types::Response<Bytes>) -> Result<Setu
         },
         Some((id, timeout_str)) => {
             if let Some(v) = timeout_str.trim().strip_prefix("timeout=") {
+                let v = v.strip_suffix(";").unwrap_or(v);
                 let timeout_sec =
-                    u32::from_str_radix(v, 10).map_err(|_| format!("Unparseable timeout {v}"))?;
+                    u32::from_str_radix(v, 10).map_err(|_| format!("Unparseable timeout [{v}]"))?;
 
                 if timeout_sec == 0 {
                     // This would make Retina send keepalives at an absurd rate; reject.

--- a/src/client/rtp.rs
+++ b/src/client/rtp.rs
@@ -135,6 +135,11 @@ impl InorderParser {
         stream_id: usize,
         data: Bytes,
     ) -> Result<Option<PacketItem>, Error> {
+        if !(data.len() >= 12 && data[0] > 127 && data[0] < 192) {
+            //this is for rtcp
+            debug!("skip invalid rtp pkt, maybe it is rtcp");
+            return Ok(None);
+        }
         let (raw, payload_range) = RawPacket::new(data).map_err(|e| {
             wrap!(ErrorInt::PacketError {
                 conn_ctx: *conn_ctx,


### PR DESCRIPTION
This PR fix some issues with some cctv providers:

- Some cctv send rtcp in same channel with rtp
- Some cctv have complex timeout field