### PR TITLE
Support setting fmtp even when rtp type does not match with a warning.

### DIFF
--- a/src/client/parse.rs
+++ b/src/client/parse.rs
@@ -293,9 +293,12 @@ fn parse_media(base_url: &Url, media_description: &Media) -> Result<Stream, Stri
                     .value
                     .as_ref()
                     .ok_or_else(|| "fmtp attribute with no value".to_string())?;
-
                 if let Some((fmtp_payload_type, v)) = v.split_once(' ') {
-                    if fmtp_payload_type == rtp_payload_type_str {
+                    let payload_type_equal = fmtp_payload_type == rtp_payload_type_str;
+                    if payload_type_equal || fmtp.is_none() {
+                        if !payload_type_equal {
+                            warn!("fmtp payload type '{}' doesn't match rtp payload type '{}'. using fmtp payload type", fmtp_payload_type, rtp_payload_type_str);
+                        }
                         fmtp = Some(v);
                     }
                 } else {
@@ -1284,6 +1287,35 @@ mod tests {
             ParametersRef::Audio(_) => {}
             _ => panic!(),
         };
+    }
+
+    #[test]
+    fn vitek() {
+        init_logging();
+        let p = parse_describe(
+            "rtsp://192.168.1.123:554/chID=8&streamType=sub",
+            include_bytes!("testdata/vitek_describe.txt"),
+        )
+        .unwrap();
+
+        // Abridged test; similar to the other Dahua test.
+        assert_eq!(p.streams.len(), 2);
+        assert_eq!(p.streams[0].media(), "video");
+        assert_eq!(p.streams[0].encoding_name(), "h265");
+        //assert_eq!(p.streams[0].rtp_payload_type, 98);
+
+        if cfg!(feature = "h265") {
+            assert!(p.streams[0].parameters().is_some());
+            assert_eq!(p.streams[1].media(), "audio");
+            assert_eq!(p.streams[1].encoding_name(), "pcmu");
+            assert_eq!(p.streams[1].rtp_payload_type, 0);
+            match p.streams[1].parameters().unwrap() {
+                ParametersRef::Audio(_) => {}
+                _ => panic!(),
+            };
+        } else {
+            assert!(p.streams[0].parameters().is_none());
+        }
     }
 
     #[test]

--- a/src/client/testdata/vitek_describe.txt
+++ b/src/client/testdata/vitek_describe.txt
@@ -1,0 +1,29 @@
+RTSP/1.0 200 OK
+Server: Server/1.0.0
+CSeq: 1
+Last-Modified: Mon Jul  8 13:51:49 2024 GMT
+Cache-Control: must-revalidate
+Date: Wed, Mar 26 2025 18:45:11 GMT
+Expires: Wed, Mar 26 2025 18:45:11 GMT
+Content-Type: application/sdp
+x-Accept-Retransmit: our-retransmit
+x-Accept-Dynamic-Rate: 1
+Content-Length: 460
+Content-Base: rtsp://192.168.1.123:554/chID=2&streamType=sub/
+
+v=0
+o=- 42329460 1 IN IP4 192.168.1.123
+s=RTSP SESSION
+u=http:///
+e=admin@
+t=0 0
+a=control:*
+a=range:npt=00.000- 
+m=video 0 RTP/AVP 98
+a=control:trackID=0
+a=rtpmap:98 H265/90000
+a=fmtp:62 profile-level-id=42e032; sprop-vps=QAEMAf//AWAAAAMAAAMAAAMAAAMAlqwJ;sprop-sps=QgEBAWAAAAMAAAMAAAMAAAMAlqALCA8f4qtO6JLuQgAAAwAIAG3dAAzf5gBA;sprop-pps=RAHAcvAbJA==; packetization-mode=1
+m=audio 0 RTP/AVP 0
+a=control:trackID=1
+a=rtpmap:0 PCMU/8000
+a=ptime:40


### PR DESCRIPTION
## Issue
When the rtp type does not match the fmtp type the current behavior is to fail (ie: too pedantic of a parse in this case as it does work if we ignore that).

## Changes
- I've changed the behavior so that we will try the non-matching fmtp type as a last resort instead of failing immediately
- Added a test using the RTSP DESCRIBE for a camera with this issue