### PR TITLE
Tolerate FU/FU-A with both S and E bits set

### DIFF
--- a/src/codec/h264.rs
+++ b/src/codec/h264.rs
@@ -498,24 +498,22 @@ impl Depacketizer {
                 if !end && mark {
                     return Err("FU-A pkt with MARK && !END".into());
                 }
-                match (start, access_unit.fu_a.take()) {
+                let fu_a = match (start, access_unit.fu_a.take()) {
                     (true, Some(_)) => {
                         return Err("FU-A with start bit while frag in progress".into());
                     }
                     (true, None) => {
-                        if end {
+                        if end && !self.seen_single_fragment_fu_a {
                             // RFC 6184 section 5.8: "the Start bit and End bit MUST NOT both be
                             // set to one in the same FU header". Some cameras violate this by
                             // wrapping small NALs in a single-fragment FU-A.
                             // Tolerate by treating them as a complete NAL.
-                            if !self.seen_single_fragment_fu_a {
-                                log::warn!(
-                                    "FU-A header {fu_header:02x} has both start and end bits set; \
-                                     treating as a complete NAL. \
-                                     Will not log about this again for this stream."
-                                );
-                                self.seen_single_fragment_fu_a = true;
-                            }
+                            log::warn!(
+                                "FU-A header {fu_header:02x} has both start and end bits set; \
+                                 treating as a complete NAL. \
+                                 Will not log about this again for this stream."
+                            );
+                            self.seen_single_fragment_fu_a = true;
                         }
                         let mut cur_nal = Some(CurFuANal {
                             hdr: nal_header,
@@ -523,21 +521,9 @@ impl Depacketizer {
                             pieces_bytes: 0,
                         });
                         self.add_fu_a(&mut cur_nal, data)?;
-                        if end {
-                            if let Some(cur_nal) = cur_nal {
-                                self.nals.push(Nal {
-                                    hdr: cur_nal.hdr,
-                                    next_piece_idx: u32::try_from(self.pieces.len())
-                                        .map_err(|_| "more than u32::MAX pieces!")?,
-                                    len: u32::try_from(cur_nal.pieces_bytes + 1)
-                                        .map_err(|_| "excessively long FU-A NAL")?,
-                                });
-                            }
-                        } else {
-                            access_unit.fu_a = Some(FuA {
-                                initial_nal_header: nal_header,
-                                cur_nal,
-                            });
+                        FuA {
+                            initial_nal_header: nal_header,
+                            cur_nal,
                         }
                     }
                     (false, Some(mut fu_a)) => {
@@ -552,21 +538,7 @@ impl Depacketizer {
                             self.seen_inconsistent_fu_a_nal_hdr = true;
                         }
                         self.add_fu_a(&mut fu_a.cur_nal, data)?;
-                        if end {
-                            if let Some(cur_nal) = fu_a.cur_nal {
-                                self.nals.push(Nal {
-                                    hdr: cur_nal.hdr,
-                                    next_piece_idx: u32::try_from(self.pieces.len())
-                                        .map_err(|_| "more than u32::MAX pieces!")?,
-                                    len: u32::try_from(cur_nal.pieces_bytes + 1)
-                                        .map_err(|_| "excessively long FU-A NAL")?,
-                                });
-                            }
-                        } else if mark {
-                            return Err("FU-A has MARK and no END".into());
-                        } else {
-                            access_unit.fu_a = Some(fu_a);
-                        }
+                        fu_a
                     }
                     (false, None) => {
                         if loss > 0 {
@@ -580,6 +552,19 @@ impl Depacketizer {
                         }
                         return Err("FU-A has start bit unset while no frag in progress".into());
                     }
+                };
+                if end {
+                    if let Some(cur_nal) = fu_a.cur_nal {
+                        self.nals.push(Nal {
+                            hdr: cur_nal.hdr,
+                            next_piece_idx: u32::try_from(self.pieces.len())
+                                .map_err(|_| "more than u32::MAX pieces!")?,
+                            len: u32::try_from(cur_nal.pieces_bytes + 1)
+                                .map_err(|_| "excessively long FU-A NAL")?,
+                        });
+                    }
+                } else {
+                    access_unit.fu_a = Some(fu_a);
                 }
             }
             _ => return Err(format!("bad nal header {nal_header:02x}")),

--- a/src/codec/h264.rs
+++ b/src/codec/h264.rs
@@ -106,6 +106,10 @@ pub(crate) struct Depacketizer {
     /// fragments.
     seen_inconsistent_fu_a_nal_hdr: bool,
 
+    /// True if we've seen a FU-A with both S and E bits set (a single-fragment
+    /// FU-A, forbidden by RFC 6184 section 5.8).
+    seen_single_fragment_fu_a: bool,
+
     /// Output format controlling NAL framing and parameter set insertion.
     frame_format: super::FrameFormat,
 }
@@ -257,6 +261,7 @@ impl Depacketizer {
             nals: Vec::new(),
             parameters,
             seen_inconsistent_fu_a_nal_hdr: false,
+            seen_single_fragment_fu_a: false,
             frame_format: Default::default(),
         })
     }
@@ -490,9 +495,6 @@ impl Depacketizer {
                     NalHeader::new((nal_header & 0b011100000) | (fu_header & 0b00011111))
                         .expect("NalHeader is valid");
                 data.advance(2);
-                if start && end {
-                    return Err(format!("Invalid FU-A header {fu_header:02x}"));
-                }
                 if !end && mark {
                     return Err("FU-A pkt with MARK && !END".into());
                 }
@@ -501,16 +503,42 @@ impl Depacketizer {
                         return Err("FU-A with start bit while frag in progress".into());
                     }
                     (true, None) => {
+                        if end {
+                            // RFC 6184 section 5.8: "the Start bit and End bit MUST NOT both be
+                            // set to one in the same FU header". Some cameras violate this by
+                            // wrapping small NALs in a single-fragment FU-A.
+                            // Tolerate by treating them as a complete NAL.
+                            if !self.seen_single_fragment_fu_a {
+                                log::warn!(
+                                    "FU-A header {fu_header:02x} has both start and end bits set; \
+                                     treating as a complete NAL. \
+                                     Will not log about this again for this stream."
+                                );
+                                self.seen_single_fragment_fu_a = true;
+                            }
+                        }
                         let mut cur_nal = Some(CurFuANal {
                             hdr: nal_header,
                             trailing_zeros: 0,
                             pieces_bytes: 0,
                         });
                         self.add_fu_a(&mut cur_nal, data)?;
-                        access_unit.fu_a = Some(FuA {
-                            initial_nal_header: nal_header,
-                            cur_nal,
-                        });
+                        if end {
+                            if let Some(cur_nal) = cur_nal {
+                                self.nals.push(Nal {
+                                    hdr: cur_nal.hdr,
+                                    next_piece_idx: u32::try_from(self.pieces.len())
+                                        .map_err(|_| "more than u32::MAX pieces!")?,
+                                    len: u32::try_from(cur_nal.pieces_bytes + 1)
+                                        .map_err(|_| "excessively long FU-A NAL")?,
+                                });
+                            }
+                        } else {
+                            access_unit.fu_a = Some(FuA {
+                                initial_nal_header: nal_header,
+                                cur_nal,
+                            });
+                        }
                     }
                     (false, Some(mut fu_a)) => {
                         if nal_header != fu_a.initial_nal_header
@@ -2611,6 +2639,51 @@ mod tests {
             &b"\x00\x00\x00\x24\x21start of non-idra wild sps appeared"
         );
         assert!(d.seen_inconsistent_fu_a_nal_hdr);
+    }
+
+    /// Tests that a FU-A with both S and E bits set is treated as a complete NAL
+    /// rather than rejected. RFC 6184 section 5.8 forbids this, but some cameras
+    /// send it anyway for small NALs.
+    #[test]
+    fn single_fragment_fu_a() {
+        init_logging();
+        let mut d = super::Depacketizer::new(90_000, Some("packetization-mode=1;profile-level-id=64001E;sprop-parameter-sets=Z2QAHqwsaoLA9puCgIKgAAADACAAAAMD0IAA,aO4xshsA")).unwrap();
+        d.set_frame_format(crate::codec::FrameFormat {
+            parameter_set_insertion: crate::codec::ParameterSetInsertion::Never,
+            ..Default::default()
+        });
+        let timestamp = crate::Timestamp {
+            timestamp: 0,
+            clock_rate: NonZeroU32::new(90_000).unwrap(),
+            start: 0,
+        };
+        assert!(!d.seen_single_fragment_fu_a);
+        d.push(
+            ReceivedPacketBuilder {
+                // FU-A with S=1 E=1 type=1 (non-IDR slice) — FU header 0xc1,
+                // as observed in the wild.
+                // FU indicator \x7c = F=0 NRI=3 type=28.
+                ctx: crate::PacketContext::dummy(),
+                stream_id: 0,
+                timestamp,
+                ssrc: 0,
+                sequence_number: 0,
+                loss: 0,
+                mark: true,
+                payload_type: 0,
+            }
+            .build(*b"\x7c\xc1small nal")
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(d.seen_single_fragment_fu_a);
+        let frame = match d.pull() {
+            Some(Ok(CodecItem::VideoFrame(frame))) => frame,
+            o => panic!("unexpected pull result: {o:?}"),
+        };
+        // Reconstructed NAL: NRI=3 (from indicator) | type=1 (from FU hdr)
+        // = 0x61, then payload. Length = 1 + 9 = 10 = 0x0a.
+        assert_eq_hex!(frame.data(), b"\x00\x00\x00\x0a\x61small nal");
     }
 
     /// Tests that empty FU-A fragments (no payload bytes after the 2-byte header) are

--- a/src/codec/h265.rs
+++ b/src/codec/h265.rs
@@ -57,6 +57,10 @@ pub(crate) struct Depacketizer {
     /// fragments.
     seen_inconsistent_fu_nal_hdr: bool,
 
+    /// True if we've seen a FU with both S and E bits set (a single-fragment
+    /// FU, forbidden by RFC 7798 section 4.4.3).
+    seen_single_fragment_fu: bool,
+
     /// Output format controlling NAL framing and parameter set insertion.
     frame_format: super::FrameFormat,
 }
@@ -152,6 +156,7 @@ impl Depacketizer {
             nals: Vec::new(),
             parameters,
             seen_inconsistent_fu_nal_hdr: false,
+            seen_single_fragment_fu: false,
             frame_format: Default::default(),
         })
     }
@@ -382,9 +387,6 @@ impl Depacketizer {
                 // Note: as only `tx-mode` `SRST` is supported, there is no DONL
                 // field to decode.
 
-                if start && end {
-                    return Err(format!("Invalid FU header {fu_header:02x}"));
-                }
                 if !end && mark {
                     return Err("FU pkt with MARK && !END".into());
                 }
@@ -393,13 +395,28 @@ impl Depacketizer {
                 match (start, access_unit.in_fu) {
                     (true, true) => return Err("FU with start bit while frag in progress".into()),
                     (true, false) => {
-                        self.add_piece(data)?;
+                        if end {
+                            // RFC 7798 section 4.4.3: "the Start bit and End bit MUST NOT both be
+                            // set to one in the same FU header". Some cameras violate this by
+                            // wrapping small NALs in a single-fragment FU.
+                            // Tolerate by treating them as a complete NAL.
+                            if !self.seen_single_fragment_fu {
+                                log::warn!(
+                                    "FU header {fu_header:02x} has both start and end bits set; \
+                                     treating as a complete NAL. \
+                                     Will not log about this again for this stream."
+                                );
+                                self.seen_single_fragment_fu = true;
+                            }
+                        }
+                        let pieces = self.add_piece(data)?;
                         self.nals.push(Nal {
                             hdr,
-                            next_piece_idx: u32::MAX, // should be overwritten later.
+                            // Overwritten on the end fragment — which may be now.
+                            next_piece_idx: if end { pieces } else { u32::MAX },
                             len: 2 + u32_len,
                         });
-                        access_unit.in_fu = true;
+                        access_unit.in_fu = !end;
                     }
                     (false, true) => {
                         let pieces = self.add_piece(data)?;
@@ -1308,6 +1325,46 @@ mod tests {
         };
         assert_eq_hex!(frame.data(), b"\x00\x00\x00\x12\x28\x01fu start, fu end");
         assert!(d.seen_inconsistent_fu_nal_hdr);
+    }
+
+    /// Tests that a FU with both S and E bits set is treated as a complete NAL
+    /// rather than rejected. RFC 7798 section 4.4.3 forbids this, but some cameras
+    /// send it anyway for small NALs.
+    #[test]
+    fn single_fragment_fu() {
+        init_logging();
+        let mut d = super::Depacketizer::new(90_000, None).unwrap();
+        let timestamp = crate::Timestamp {
+            timestamp: 0,
+            clock_rate: NonZeroU32::new(90_000).unwrap(),
+            start: 0,
+        };
+        assert!(!d.seen_single_fragment_fu);
+        d.push(
+            ReceivedPacketBuilder {
+                // FU packet with S=1 E=1 FuType=1 (TRAIL_R) — header 0xc1,
+                // as observed in the wild.
+                ctx: PacketContext::dummy(),
+                stream_id: 0,
+                timestamp,
+                ssrc: 0,
+                sequence_number: 0,
+                loss: 0,
+                mark: true,
+                payload_type: 0,
+            }
+            .build(*b"\x62\x01\xc1small nal")
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(d.seen_single_fragment_fu);
+        let frame = match d.pull() {
+            Some(Ok(CodecItem::VideoFrame(frame))) => frame,
+            o => panic!("unexpected pull result: {o:?}"),
+        };
+        // Reconstructed NAL: type=1 layer=0 TID=1 -> header \x02\x01, then payload.
+        // Length = 2 (header) + 9 (payload) = 11 = 0x0b.
+        assert_eq_hex!(frame.data(), b"\x00\x00\x00\x0b\x02\x01small nal");
     }
 
     /// Tests that empty FU fragments (no payload bytes after the FU header) are

--- a/src/codec/h265.rs
+++ b/src/codec/h265.rs
@@ -392,31 +392,28 @@ impl Depacketizer {
                 }
                 let u32_len = u32::try_from(data.len())
                     .map_err(|_| "RTP packet len must be < u16::MAX".to_string())?;
-                match (start, access_unit.in_fu) {
+                let pieces = match (start, access_unit.in_fu) {
                     (true, true) => return Err("FU with start bit while frag in progress".into()),
                     (true, false) => {
-                        if end {
+                        if end && !self.seen_single_fragment_fu {
                             // RFC 7798 section 4.4.3: "the Start bit and End bit MUST NOT both be
                             // set to one in the same FU header". Some cameras violate this by
                             // wrapping small NALs in a single-fragment FU.
                             // Tolerate by treating them as a complete NAL.
-                            if !self.seen_single_fragment_fu {
-                                log::warn!(
-                                    "FU header {fu_header:02x} has both start and end bits set; \
-                                     treating as a complete NAL. \
-                                     Will not log about this again for this stream."
-                                );
-                                self.seen_single_fragment_fu = true;
-                            }
+                            log::warn!(
+                                "FU header {fu_header:02x} has both start and end bits set; \
+                                 treating as a complete NAL. \
+                                 Will not log about this again for this stream."
+                            );
+                            self.seen_single_fragment_fu = true;
                         }
                         let pieces = self.add_piece(data)?;
                         self.nals.push(Nal {
                             hdr,
-                            // Overwritten on the end fragment — which may be now.
-                            next_piece_idx: if end { pieces } else { u32::MAX },
+                            next_piece_idx: u32::MAX, // should be overwritten later.
                             len: 2 + u32_len,
                         });
-                        access_unit.in_fu = !end;
+                        pieces
                     }
                     (false, true) => {
                         let pieces = self.add_piece(data)?;
@@ -434,12 +431,7 @@ impl Depacketizer {
                             self.seen_inconsistent_fu_nal_hdr = true;
                         }
                         nal.len += u32_len;
-                        if end {
-                            nal.next_piece_idx = pieces;
-                            access_unit.in_fu = false;
-                        } else if mark {
-                            return Err("FU has MARK and no END".into());
-                        }
+                        pieces
                     }
                     (false, false) => {
                         if loss > 0 {
@@ -453,7 +445,14 @@ impl Depacketizer {
                         }
                         return Err("FU has start bit unset while no frag in progress".into());
                     }
+                };
+                if end {
+                    self.nals
+                        .last_mut()
+                        .expect("both match arms reaching here ensure a last nal")
+                        .next_piece_idx = pieces;
                 }
+                access_unit.in_fu = !end;
             }
             _ => return Err(format!("unexpected/bad nal header {hdr:?}")),
         }


### PR DESCRIPTION
On my IMX415-based SSC378DE (Infinity6c family) OpenIPC camera I have observed intermittent packets that have both start and end bits set, both for H.264 and H.265.

This PR proposes to warn once when these are encountered and to otherwise struggle on, treating them as a complete NAL.
Previously this caused an `Invalid FU-A header c1` / `Invalid FU header c1` error and stream teardown.

Before: H.265 8/8 runs failed within 3–69s; H.264 intermittent as FU-A errors occur less frequently than with H.265.
After: 3/3 H.265 × 120s and 3/3 H.264 × 180s runs complete cleanly, all frames decode without error.