### PR TITLE
ignore unparseable `ssrc` in SETUP Transport header

### DIFF
--- a/src/client/parse.rs
+++ b/src/client/parse.rs
@@ -567,9 +567,15 @@ pub(crate) fn parse_setup(response: &crate::rtsp::msg::Response) -> Result<Setup
     let transport_str: &str = transport;
     for part in transport_str.split(';') {
         if let Some(v) = part.strip_prefix("ssrc=") {
+            // Some cameras (eg Rubetek) send `ssrc=0x6f7c`, where RFC 2326
+            // section 12.39 asks for eight hex digits without a prefix. The
+            // value is advisory: when absent, the SSRC is learned from the
+            // first RTP packet. So warn and ignore it rather than fail SETUP.
             let v = v.trim();
-            let v = u32::from_str_radix(v, 16).map_err(|_| format!("Unparseable ssrc {v}"))?;
-            ssrc = Some(v);
+            match u32::from_str_radix(v, 16) {
+                Ok(v) => ssrc = Some(v),
+                Err(_) => warn!("Ignoring unparseable ssrc in Transport header {transport_str:?}"),
+            }
         } else if let Some(interleaved) = part.strip_prefix("interleaved=") {
             let mut channels = interleaved.splitn(2, '-');
             let n = channels.next().expect("splitn returns at least one part");
@@ -1559,6 +1565,28 @@ mod tests {
                 },
                 channel_id: Some(0),
                 ssrc: Some(0x0d6d6627),
+                server_port: None,
+            }
+        );
+    }
+
+    /// Rubetek cameras send the SSRC with a `0x` prefix in the Transport
+    /// header (e.g. `ssrc=0x6f7c`). Ignore it rather than fail SETUP.
+    #[test]
+    fn rubetek_ssrc_with_0x_prefix() {
+        init_logging();
+        let setup_response = response(include_bytes!("testdata/rubetek_setup_ssrc_0x.txt"));
+        let r = parse_setup(&setup_response.0).unwrap();
+        assert_eq!(
+            r,
+            SetupResponse {
+                source: None,
+                session: SessionHeader {
+                    id: "5657612475258969210".into(),
+                    timeout_sec: 60,
+                },
+                channel_id: Some(0),
+                ssrc: None,
                 server_port: None,
             }
         );

--- a/src/client/testdata/rubetek_setup_ssrc_0x.txt
+++ b/src/client/testdata/rubetek_setup_ssrc_0x.txt
@@ -1,0 +1,6 @@
+RTSP/1.0 200 OK
+CSeq: 4
+Session: 5657612475258969210
+Transport: RTP/AVP/TCP;unicast;interleaved=0-1;ssrc=0x6f7c;mode="PLAY"
+WWW-Authenticate: Digest realm="Rubetek IP camera device",nonce="7257f76204da0f14294c763e2fba0411"
+


### PR DESCRIPTION
Captured SETUP response (video track; the audio track gets `ssrc=0x6f7d`):

```
Transport: RTP/AVP/TCP;unicast;interleaved=0-1;ssrc=0x6f7c;mode="PLAY"
```

Fails with `200 response to SETUP CSeq=3: Unparseable ssrc 0x6f7c`;
ffmpeg plays the same camera fine. Ignoring the value rather than stripping
the prefix also avoids a hard "wrong ssrc" error if the advertised value does
not match the packets. This camera's PLAY response has no `ssrc` in RTP-Info,
so only `parse_setup` is touched.

